### PR TITLE
fix: link extraction broken on games without "REALLY Fucking Fast" span

### DIFF
--- a/get_links.py
+++ b/get_links.py
@@ -1,63 +1,52 @@
-import requests, os, sys, pyperclip
+import requests, os, pyperclip
 from bs4 import BeautifulSoup
 from datetime import datetime
 from colorama import Fore, Style
-
 class console:
     def __init__(self) -> None:
         self.colors = {"green": Fore.GREEN, "red": Fore.RED, "yellow": Fore.YELLOW, "blue": Fore.BLUE, "magenta": Fore.MAGENTA, "cyan": Fore.CYAN, "white": Fore.WHITE, "black": Fore.BLACK, "reset": Style.RESET_ALL, "lightblack": Fore.LIGHTBLACK_EX, "lightred": Fore.LIGHTRED_EX, "lightgreen": Fore.LIGHTGREEN_EX, "lightyellow": Fore.LIGHTYELLOW_EX, "lightblue": Fore.LIGHTBLUE_EX, "lightmagenta": Fore.LIGHTMAGENTA_EX, "lightcyan": Fore.LIGHTCYAN_EX, "lightwhite": Fore.LIGHTWHITE_EX}
-
     def clear(self):
         os.system("cls" if os.name == "nt" else "clear")
-
     def timestamp(self):
         return datetime.now().strftime("%H:%M:%S")
-    
     def success(self, message, obj):
         print(f"{self.colors['lightblack']}{self.timestamp()} » {self.colors['lightgreen']}SUCC {self.colors['lightblack']}• {self.colors['white']}{message} : {self.colors['lightgreen']}{obj}{self.colors['white']} {self.colors['reset']}")
-
     def error(self, message, obj):
         print(f"{self.colors['lightblack']}{self.timestamp()} » {self.colors['lightred']}ERRR {self.colors['lightblack']}• {self.colors['white']}{message} : {self.colors['lightred']}{obj}{self.colors['white']} {self.colors['reset']}")
-
     def done(self, message, obj):
         print(f"{self.colors['lightblack']}{self.timestamp()} » {self.colors['lightmagenta']}DONE {self.colors['lightblack']}• {self.colors['white']}{message} : {self.colors['lightmagenta']}{obj}{self.colors['white']} {self.colors['reset']}")
-
     def warning(self, message, obj):
         print(f"{self.colors['lightblack']}{self.timestamp()} » {self.colors['lightyellow']}WARN {self.colors['lightblack']}• {self.colors['white']}{message} : {self.colors['lightyellow']}{obj}{self.colors['white']} {self.colors['reset']}")
-
     def info(self, message, obj):
         print(f"{self.colors['lightblack']}{self.timestamp()} » {self.colors['lightblue']}INFO {self.colors['lightblack']}• {self.colors['white']}{message} : {self.colors['lightblue']}{obj}{self.colors['white']} {self.colors['reset']}")
-
     def custom(self, message, obj, color):
         print(f"{self.colors['lightblack']}{self.timestamp()} » {self.colors[color.upper()]}{color.upper()} {self.colors['lightblack']}• {self.colors['white']}{message} : {self.colors[color.upper()]}{obj}{self.colors['white']} {self.colors['reset']}")
-
     def input(self, message):
         return input(f"{self.colors['lightblack']}{self.timestamp()} » {self.colors['lightcyan']}INPUT   {self.colors['lightblack']}• {self.colors['white']}{message}{self.colors['reset']}")
-
 log = console()
 log.clear()
-r = requests.get(log.input("Enter Fitgirl Game Link : "))
-r.raise_for_status()  # fail fast on HTTP errors instead of silently parsing a bad response
+
+url = log.input("Enter Fitgirl Game Link : ")
+try:
+    r = requests.get(url)
+    r.raise_for_status()  # fail fast on HTTP errors instead of silently parsing a bad response
+except requests.exceptions.RequestException as e:
+    log.error("HTTP request failed", f"{url} ({e})")
+    raise SystemExit(1)
 
 soup = BeautifulSoup(r.text, "html.parser")
-
 # each filehoster has its own dlinks div; find_all catches all of them
 links = [
     a["href"]
-    for spoiler in soup.find_all("div", class_="dlinks")
-    for a in spoiler.find_all("a", href=True)
+    for dlinks_div in soup.find_all("div", class_="dlinks")
+    for a in dlinks_div.find_all("a", href=True)
     if a["href"].startswith("https://fuckingfast.co/")
 ]
-
-
 if not links:
     log.error("No Matching URLs Found", "Retry..")
 else:
     output = "\n".join(links)
-
     print("🔗 Matching URLs :")
     print(output)
-
     pyperclip.copy(output)
-    
     log.success("All Links Copied To Clipboard", len(links))

--- a/get_links.py
+++ b/get_links.py
@@ -37,29 +37,14 @@ class console:
 log = console()
 log.clear()
 r = requests.get(log.input("Enter Fitgirl Game Link : "))
+r.raise_for_status()  # fail fast on HTTP errors instead of silently parsing a bad response
 
 soup = BeautifulSoup(r.text, "html.parser")
 
-text_span = soup.find(
-    "span",
-    string=lambda s: s and "REALLY Fucking Fast" in s
-)
-
-if not text_span:
-    log.error("Text Not Found", "REALLY Fucking Fast")
-    sys.exit()
-
-spoiler = text_span.find_next(
-    "div",
-    class_="su-spoiler"
-)
-
-if not spoiler:
-    log.error("Spoiler Container Not Found", "su-spoiler")
-    sys.exit()
-
+# each filehoster has its own dlinks div; find_all catches all of them
 links = [
     a["href"]
+    for spoiler in soup.find_all("div", class_="dlinks")
     for a in spoiler.find_all("a", href=True)
     if a["href"].startswith("https://fuckingfast.co/")
 ]


### PR DESCRIPTION
The span text lookup failed on games where "REALLY Fucking Fast" isn't wrapped in a `<span>` tag, which isn't consistent across all game pages.

Every filehoster section uses `class="dlinks"` consistently, so targeting 
that directly with find_all works across all game pages.

Also adds `raise_for_status()` so HTTP errors surface immediately instead 
of silently failing as "no links found".