### PR TITLE
fix: empty input.txt guard and game subfolder for downloads

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,6 +84,10 @@ def remove_link(processed_link, input_file='input.txt'):
 with open('input.txt', 'r') as file:
     links = [line.strip() for line in file if line.strip()]
 
+if not links:
+    log.warning("input.txt is empty", "add links and rerun")
+    raise SystemExit(0)
+
 for link in links:
     log.info(f"Started Processing", f"{link[:30]}...{link[60:]}")
     response = requests.get(link, headers=headers)

--- a/main.py
+++ b/main.py
@@ -36,8 +36,6 @@ class console:
     def input(self, message):
         return input(f"{self.colors['lightblack']}{self.timestamp()} » {self.colors['lightcyan']}INPUT   {self.colors['lightblack']}• {self.colors['white']}{message}{self.colors['reset']}")
 
-downloads_folder = "downloads"
-os.makedirs(downloads_folder, exist_ok=True)
 log = console()
 log.clear()
 
@@ -65,7 +63,7 @@ def download_file(download_url, output_path):
         ) as bar:
             for data in response.iter_content(block_size):
                 f.write(data)
-                bar.set_description(f"{log.colors['lightblack']}{log.timestamp()} » {log.colors['lightblue']}INFO {log.colors['lightblack']}• {log.colors['white']}Downloading -> {output_path[:15]}...{output_path[55:]} {log.colors['reset']}")
+                bar.set_description(f"{log.colors['lightblack']}{log.timestamp()} » {log.colors['lightblue']}INFO {log.colors['lightblack']}• {log.colors['white']}Downloading -> {os.path.basename(output_path)[:55]} {log.colors['reset']}")
                 bar.update(len(data))
 
         log.success(f"Successfully Downloaded File", F"{output_path[:35]}...{output_path[55:]}")
@@ -87,6 +85,10 @@ with open('input.txt', 'r') as file:
 if not links:
     log.warning("input.txt is empty", "add links and rerun")
     raise SystemExit(0)
+
+game_name = links[0].split("#")[-1].split("--")[0].strip("_")
+downloads_folder = os.path.join("downloads", game_name)
+os.makedirs(downloads_folder, exist_ok=True)
 
 for link in links:
     log.info(f"Started Processing", f"{link[:30]}...{link[60:]}")

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os, re, requests
+from urllib.parse import urlparse
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 from datetime import datetime
@@ -84,11 +85,13 @@ with open('input.txt', 'r') as file:
 
 if not links:
     log.warning("input.txt is empty", "add links and rerun")
-    raise SystemExit(0)
+    raise SystemExit(1)
 
-game_name = links[0].split("#")[-1].split("--")[0].strip("_")
+fragment = urlparse(links[0]).fragment
+game_name = fragment.split("--")[0].strip("_") if fragment else "unknown_game"
 downloads_folder = os.path.join("downloads", game_name)
 os.makedirs(downloads_folder, exist_ok=True)
+log.info("Download folder", downloads_folder)
 
 for link in links:
     log.info(f"Started Processing", f"{link[:30]}...{link[60:]}")


### PR DESCRIPTION
Running main.py with an empty input.txt silently did nothing with no feedback.

All downloaded files were saved flat into downloads/ regardless of game, making 
it messy when downloading multiple games.

- Exit with a warning when input.txt is empty instead of silently doing nothing
- Derive game name from the URL fragment and save files to `downloads/<game-name>/`