### PR TITLE
fix: derive game name from part files instead of first link

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,8 +88,10 @@ if not links:
     raise SystemExit(1)
 
 first_game_link = next((l for l in links if "fitgirl-repacks.site" in urlparse(l).fragment), None)
-fragment = urlparse(first_game_link).fragment if first_game_link else ""
-game_name = fragment.split("--")[0].strip("_") if fragment else "unknown_game"
+if not first_game_link:
+    log.error("Could not determine game name", "no fitgirl part files found in input.txt")
+    raise SystemExit(1)
+game_name = urlparse(first_game_link).fragment.split("--")[0].strip("_")
 downloads_folder = os.path.join("downloads", game_name)
 os.makedirs(downloads_folder, exist_ok=True)
 log.info("Download folder", downloads_folder)

--- a/main.py
+++ b/main.py
@@ -87,7 +87,8 @@ if not links:
     log.warning("input.txt is empty", "add links and rerun")
     raise SystemExit(1)
 
-fragment = urlparse(links[0]).fragment
+first_game_link = next((l for l in links if "fitgirl-repacks.site" in urlparse(l).fragment), None)
+fragment = urlparse(first_game_link).fragment if first_game_link else ""
 game_name = fragment.split("--")[0].strip("_") if fragment else "unknown_game"
 downloads_folder = os.path.join("downloads", game_name)
 os.makedirs(downloads_folder, exist_ok=True)


### PR DESCRIPTION
`game_name` was derived from `links[0]`, which isn't always a game part file.
Games like GTA V include `setup_proper.exe` as the first link, producing
`downloads/setup_proper.exe/` as the output folder.

Use the first link whose fragment contains `fitgirl-repacks.site` instead,
which is present in every game part filename and only in those.