### PR TITLE
chore: add requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,9 @@ This Tool Helps To Download Multiple Files Easily From fitgirl-repacks.site Thro
 Ensure you have the following installed before running the script :
 
 - Python 3.8+
-- Required Python packages :
-  - `requests`
-  - `beautifulsoup4`
-  - `tqdm`
-  - `colorama`
-  - `pyperclip`
 
 ```bash
-pip install requests beautifulsoup4 tqdm colorama pyperclip
+pip install -r requirements.txt
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+requests
+beautifulsoup4
+tqdm
+colorama
+pyperclip


### PR DESCRIPTION
Dependencies were only listed in the README with a manual pip install command,
which can drift out of sync as deps change.

- Adds `requirements.txt` with all five dependencies, no version pinning
- Updates README install command from manual list to `pip install -r requirements.txt`